### PR TITLE
Add deploy button for managing fighters

### DIFF
--- a/data/interfaces.txt
+++ b/data/interfaces.txt
@@ -1270,6 +1270,17 @@ interface "main buttons" bottom right
 	button j "_Jump"
 		from -160 -40 to -90 -10
 
+	visible if "can deploy"
+	sprite "ui/dialog cancel"
+		from -170 -80 to -80 -130
+	button d "_Deploy"
+		from -160 -70 to -90 -140
+
+	visible if "can recall"
+	sprite "ui/dialog cancel"
+		from -170 -80 to -80 -130
+	button d "_Recall"
+		from -160 -70 to -90 -140
 
 	visible if "has secondary"
 	active if "secondary selected"

--- a/source/MainPanel.cpp
+++ b/source/MainPanel.cpp
@@ -201,6 +201,34 @@ void MainPanel::Draw()
 			{
 				info.SetCondition("can hail");
 			}
+
+			bool hasFighters = false;
+			bool hasReservedFighters = false;
+			for (auto &ship: player.Ships())
+			{
+				if (ship->CanBeCarried() && !ship->IsParked() && !ship->IsDestroyed())
+				{
+					hasFighters = true;
+
+					if (!(ship->HasDeployOrder()))
+					{
+						hasReservedFighters = true;
+						break; // found the reserve, no need to look further
+					}
+				}
+			}
+			if (hasFighters)
+			{
+				if (hasReservedFighters)
+				{
+					info.SetCondition("can deploy");
+				}
+				else
+				{
+					info.SetCondition("can recall");
+				}
+			}
+
 			if (player.Flagship()->GetTargetShip())
 			{
 				info.SetCondition("can hail");
@@ -316,6 +344,8 @@ bool MainPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, boo
 		show.Set(Command::HAIL);
 	else if(key == SDLK_a) // synthetic keypress via UI button, not keyboard
 		Command::Inject(Command::FIGHT);
+	else if(key == SDLK_d) // synthetic keypress via UI button, not keyboard
+		Command::Inject(Command::DEPLOY);
 	else if(key == SDLK_c)
 		Command::Inject(Command::CLOAK);
 	else if(key == SDLK_w)


### PR DESCRIPTION
**Feature:** This PR implements the feature request detailed and discussed in issue #21

## Feature Details
Added a button for deploying/recalling fighters

## UI Screenshots
![deploy-btn](https://user-images.githubusercontent.com/523593/205420970-34c0c07f-fa6a-4864-933b-2e41e0406d79.png)


## Testing Done
Tested with a ship that had fighters, and with ships that didn't, ensuring the button appeared or disappeared correctly. I DID NOT test how it looks on the android app, just a super expanded UI on a desktop.

## Performance Impact
N/A

## Notes

Im not super happy with the placement, it looks OK if the flagship has a secondary weapon, otherwise there is this weird gap in the 2nd row. This is for mobile, and the right-most button slot of third row is covered by the fuel/energy/heat meters. Going further to the left on the 2nd row might be an option, but I thought itd look weird in cases where nothing is selected for attack/scan/hail. If there is a way to dynamically move the button based on visibility of other buttons, this might be worth doing, but then it would break muscle memory for anyone commonly pressing it.... SO IDK, il leave that to you.

Logic for showing the button can be simplified a little, not sure if we need to check for both existence of bays and fighters, I did so because I think its pointless to have the button if the ship has bays, but no fighters exist in the fleet, but perhaps you disagree in that, in which case we I can change that.