### PR TITLE
Remove issue contact link

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,1 @@
 blank_issues_enabled: false
-contact_links:
-  - name: Endless Sky Mobile
-    url: https://github.com/thewierdnut/endless-mobile/issues/
-    about: Please report any issues related to the mobile port here.


### PR DESCRIPTION
**New Issue Fix**

## Summary
Sorry if this isn't worth making a PR for.

---

Removes the "report any bugs with Endless Sky Mobile" button when you're making a new issue. Otherwise you can get stuck in a loop.