### PR TITLE
Updated build instructions

### DIFF
--- a/android/app/convert_linux_links_to_windows_links.ps1
+++ b/android/app/convert_linux_links_to_windows_links.ps1
@@ -1,0 +1,28 @@
+#Requires -RunAsAdministrator
+
+function Get-LinkTarget {
+    param (
+        [string] $LinkPath
+    )
+    $file = Get-Item -Path $LinkPath
+    $basePath = $File.Directory.FullName
+    $relativePath = Get-Content -Path $File -TotalCount 1
+    $targetPath = Resolve-Path -Path "$basePath\$relativePath"
+    return $targetPath
+}
+
+# /endless-mobile/android/app
+$rootDirectory = $PSScriptRoot
+
+$links = @(
+    "$rootDirectory\jni\src\SDL2"
+    "$rootDirectory\src\main\java\org\libsdl"
+    "$rootDirectory\src\main\assets\endless-sky-data\data"
+    "$rootDirectory\src\main\assets\endless-sky-data\shaders"
+    "$rootDirectory\src\main\assets\endless-sky-data\credits.txt"
+)
+Get-ChildItem -Path "$rootDirectory\src\main\res\mipmap*" -Recurse | ForEach-Object { $links += $_.FullName}
+
+$links | ForEach-Object {
+    New-Item -Path $_ -ItemType SymbolicLink -Value ((Get-LinkTarget -LinkPath $_).Path) -Force
+}

--- a/android/build_instructions.md
+++ b/android/build_instructions.md
@@ -17,6 +17,7 @@
 5. Run `gradlew.bat build` from the android directory.
 
 #### Notes
+
 - If gradle notifies you that you are missing the required ndk version, then install it via the sdk manager, and try again. 
 - Debug apk location
   - Linux: _endless-mobile/android/app/build/outputs/apk/debug/app-debug.apk_

--- a/android/build_instructions.md
+++ b/android/build_instructions.md
@@ -1,6 +1,7 @@
 # Creating Endless-Mobile Debug Build
 
 #### Initial Setup
+
 1. Run the *download_build_dependencies.sh* script to download and unpack the SDL2, turbojpeg, and png dependencies.
 2. Set the ANDROID_SDK_ROOT environment variable.
 
@@ -8,8 +9,6 @@
 
 3. Run `gradlew buildDebug` from the android directory
 4. Run `gradlew build` from the android directory.
-5. If gradle notifies you that you are missing the required ndk version, then install it via the sdk manager, and try again. 
-6. The debug apk is found at _~\endless-mobile\android\app\build\outputs\apk\debug\app-debug.apk_
 
 #### Windows
 
@@ -19,7 +18,9 @@
 
 #### Notes
 - If gradle notifies you that you are missing the required ndk version, then install it via the sdk manager, and try again. 
-- The debug apk is found at _~\endless-mobile\android\app\build\outputs\apk\debug\app-debug.apk_
+- Debug apk location
+  - Linux: _endless-mobile/android/app/build/outputs/apk/debug/app-debug.apk_
+  - Windows: _endless-mobile\android\app\build\outputs\apk\debug\app-debug.apk_
 - Builds can be installed directly to an attached Android device or emulator
     - To install, run `gradlew installDebug` or `gradlew.bat installDebug`
     - To uninstall, run `gradlew uninstallDebug` or `gradlew.bat uninstallDebug`

--- a/android/build_instructions.md
+++ b/android/build_instructions.md
@@ -1,9 +1,25 @@
-# Android Build
-These instructions have only been tested on linux based hosts. 
+# Creating Endless-Mobile Debug Build
 
-1. Run the download_build_dependencies.sh script to download and unpack the SDL2, turbojpeg, and png dependencies.
+#### Initial Setup
+1. Run the *download_build_dependencies.sh* script to download and unpack the SDL2, turbojpeg, and png dependencies.
 2. Set the ANDROID_SDK_ROOT environment variable.
-3. Run `gradlew build` from the android directory.
-4. If gradle notifies you that you are missing the required ndk version, then install it via the sdk manager, and try again. 
 
+#### Linux
 
+3. Run `gradlew buildDebug` from the android directory
+4. Run `gradlew build` from the android directory.
+5. If gradle notifies you that you are missing the required ndk version, then install it via the sdk manager, and try again. 
+6. The debug apk is found at _~\endless-mobile\android\app\build\outputs\apk\debug\app-debug.apk_
+
+#### Windows
+
+3. Run the *convert_linux_links_to_windows_links.ps1* to change the project's symbolic links from to a Windows format 
+4. Run `gradlew.bat buildDebug` from the android directory
+5. Run `gradlew.bat build` from the android directory.
+
+#### Notes
+- If gradle notifies you that you are missing the required ndk version, then install it via the sdk manager, and try again. 
+- The debug apk is found at _~\endless-mobile\android\app\build\outputs\apk\debug\app-debug.apk_
+- Builds can be installed directly to an attached Android device or emulator
+    - To install, run `gradlew installDebug` or `gradlew.bat installDebug`
+    - To uninstall, run `gradlew uninstallDebug` or `gradlew.bat uninstallDebug`

--- a/android/build_instructions.md
+++ b/android/build_instructions.md
@@ -13,7 +13,7 @@
 
 #### Windows
 
-3. Run the *convert_linux_links_to_windows_links.ps1* to change the project's symbolic links from to a Windows format 
+3. Run the *convert_linux_links_to_windows_links.ps1* to change the project's symbolic links to a Windows format 
 4. Run `gradlew.bat buildDebug` from the android directory
 5. Run `gradlew.bat build` from the android directory.
 


### PR DESCRIPTION
Added script to fix Windows build issues

**Documentation**

## Acknowledgement

- [x] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary
There were no instructions on how to build with a Windows host, and instructions would have helped me, so here are some (hopefully useful) instructions.

## Testing Done
- Starting from a brand-new clone of endless-mobile, successfully installed a debug build on the Android Emulator using the new instructions
- Clicked through settings menu
- Created a new pilot, bought a ship, launched from the starting planet and landed back on the planet


## Performance Impact
N/A