### PR TITLE
Render under display cutout on short edges

### DIFF
--- a/android/app/src/main/java/com/github/thewierdnut/endless-mobile/ESActivity.java
+++ b/android/app/src/main/java/com/github/thewierdnut/endless-mobile/ESActivity.java
@@ -2,6 +2,9 @@ package com.github.thewierdnut.endless_mobile;
 
 
 import org.libsdl.app.SDLActivity;
+import android.os.Build;
+import android.os.Bundle;
+import android.view.WindowManager;
 import android.content.Intent;
 import java.io.OutputStream;
 import java.io.InputStream;
@@ -28,6 +31,16 @@ public class ESActivity extends SDLActivity
     static int SAVE_FILE = 1;
     static int GET_FILE = 2;
     static int UNZIP_PLUGIN = 3;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState)
+    {
+        super.onCreate(savedInstanceState);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            getWindow().getAttributes().layoutInDisplayCutoutMode =
+                WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES;
+        }
+    }
 
     protected String[] getLibraries()
     {


### PR DESCRIPTION
**Feature**

## Acknowledgement

- [ ] I acknowledge that I have read and understand the [Contributing](https://github.com/endless-sky/endless-sky/blob/master/docs/CONTRIBUTING.md) article.

## Summary

On devices with a display cutout (notch or punch-hole) on a short edge, SDL's window is letterboxed away from the cutout by default, leaving a black band along that edge. This change overrides `onCreate()` in `ESActivity` to opt the window into `LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES`, so the render surface extends into the cutout area and the game uses the full screen.

The change is guarded on `Build.VERSION.SDK_INT >= Build.VERSION_CODES.P` (API 28, where the layout-in-cutout mode was introduced) and is a no-op on older devices. It adds the three imports it needs (`android.os.Build`, `android.os.Bundle`, `android.view.WindowManager`) and touches only `ESActivity.java`.

Going edge-to-edge means content can now also extend under the device's rounded corners, so UI pinned tightly to a corner may be clipped. A follow-up that pads the SDL content view by the system safe-area insets is the intended complete fix; this PR is intentionally scoped to the cutout/short-edge change and kept as a draft until that follow-up lands.

## Testing Done

- Built a debug APK (`arm64-v8a`) from the `android` branch with this change applied; the project compiles and packages cleanly (Gradle/AGP 8.7.3, NDK 26.3.11579264).
- Runtime behavior on physical hardware with a display cutout has **not** yet been verified — flagging that explicitly. Help testing on notch / punch-hole devices is welcome.

## Performance Impact

N/A — sets a single window attribute once at activity creation; no per-frame cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
